### PR TITLE
fix typo in informersMap construction

### DIFF
--- a/filteredcache/enhanced-filtered-cache.go
+++ b/filteredcache/enhanced-filtered-cache.go
@@ -105,7 +105,7 @@ func buildInformersMap(config *rest.Config, opts cache.Options, gvkLabelsMap map
 			informersMap[gvk] = append(informersMap[gvk], informer)
 			// Build list type for the GVK
 			gvkList := schema.GroupVersionKind{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind + "List"}
-			informersMap[gvkList] = append(informersMap[gvk], informer)
+			informersMap[gvkList] = append(informersMap[gvkList], informer)
 		}
 	}
 	return informersMap, nil


### PR DESCRIPTION
w/o this fix, the enhanced filter cache can still work. But informersMap[gvkList] will contain two informers, which lead to duplicate entries in list response