### PR TITLE
fix namespace for cluster scoped resource.

### DIFF
--- a/filteredcache/enhanced-filtered-cache.go
+++ b/filteredcache/enhanced-filtered-cache.go
@@ -202,9 +202,14 @@ func (efc enhancedFilteredCache) getFromClient(ctx context.Context, key client.O
 	if err != nil {
 		return err
 	}
-	result, err := client.
-		Get().
-		Namespace(key.Namespace).
+
+	// Different key for cluster scope resource and namespaced resource
+	restReq := client.Get()
+	if key.Namespace != "" {
+		restReq = restReq.Namespace(key.Namespace)
+	}
+
+	result, err := restReq.
 		Name(key.Name).
 		Resource(resource).
 		VersionedParams(&metav1.GetOptions{}, metav1.ParameterCodec).

--- a/filteredcache/filtered-cache.go
+++ b/filteredcache/filtered-cache.go
@@ -202,9 +202,14 @@ func (c filteredCache) getFromClient(ctx context.Context, key client.ObjectKey, 
 	if err != nil {
 		return err
 	}
-	result, err := client.
-		Get().
-		Namespace(key.Namespace).
+
+	// Different key for cluster scope resource and namespaced resource
+	restReq := client.Get()
+	if key.Namespace != "" {
+		restReq = restReq.Namespace(key.Namespace)
+	}
+
+	result, err := restReq.
 		Name(key.Name).
 		Resource(resource).
 		VersionedParams(&metav1.GetOptions{}, metav1.ParameterCodec).


### PR DESCRIPTION
This PR fixes the following namespace issue when get the cluster scoped resource with kube reset client:

```
{"error": "an empty namespace may not be set when a resource name is provided"}
```